### PR TITLE
Add q to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "jade": "*",
     "sharify": "*",
     "backbone": "*",
-    "backbone-super-sync": "*"
+    "backbone-super-sync": "*",
+    "q": "^1.0.1"
   },
   "devDependencies": {
     "jquery": "*",


### PR DESCRIPTION
I had to add `q` before running `make s`. This PR only contributes the result of `npm install --save q`, but I thought it was more actionable than a Github issue.
