### PR TITLE
ShouldJS .include deprecated, now uses containEql

### DIFF
--- a/src/cs-example/apps/commits/test/client.coffee
+++ b/src/cs-example/apps/commits/test/client.coffee
@@ -45,7 +45,7 @@ describe "CommitsView", ->
     it "renders the commits", ->
       @view.collection.reset [commit: { message: "Bump package.json version" }]
       @view.render()
-      @view.$el.html().should.include "Bump package.json version"
+      @view.$el.html().should.containEql "Bump package.json version"
 
   describe "#changeRepo", ->
 

--- a/src/cs-example/apps/commits/test/integration.coffee
+++ b/src/cs-example/apps/commits/test/integration.coffee
@@ -24,5 +24,5 @@ describe "commits", ->
 
   it "displays the list of commits", (done) ->
     Browser.visit "http://localhost:5000", (err, browser) ->
-      browser.html().should.include "Adding a README"
+      browser.html().should.containEql "Adding a README"
       done()

--- a/src/cs-example/apps/commits/test/routes.coffee
+++ b/src/cs-example/apps/commits/test/routes.coffee
@@ -24,7 +24,7 @@ describe "#index", ->
 
   it "fetches the artsy github commits and renders the index page", ->
     routes.index @req, @res
-    Backbone.sync.args[0][1].url().should.include "/repos/artsy/flare/commits"
+    Backbone.sync.args[0][1].url().should.containEql "/repos/artsy/flare/commits"
     Backbone.sync.args[0][2].success [message: "hi"]
     @res.render.args[0][0].should.equal "index"
     @res.render.args[0][1].commits[0].get("message").should.equal "hi"

--- a/src/cs-example/test/models/commit.coffee
+++ b/src/cs-example/test/models/commit.coffee
@@ -16,4 +16,4 @@ describe "Commit", ->
       @commit.collection = new Commits null,
         owner: "foo"
         repo: "bar"    
-      @commit.url().should.include "/repos/foo/bar/qux"
+      @commit.url().should.containEql "/repos/foo/bar/qux"

--- a/src/js-example/apps/commits/test/client.js
+++ b/src/js-example/apps/commits/test/client.js
@@ -60,7 +60,7 @@ describe('CommitsView', function() {
         { commit: { message: 'Bump package.json version'} }
       ]);
       view.render();
-      view.$el.html().should.include('Bump package.json version');
+      view.$el.html().should.containEql('Bump package.json version');
     });
   });
 

--- a/src/js-example/apps/commits/test/integration.js
+++ b/src/js-example/apps/commits/test/integration.js
@@ -28,7 +28,7 @@ describe('commits', function() {
 
   it('displays the list of commits', function(done) {
     Browser.visit('http://localhost:5000', function(err, browser) {
-      browser.html().should.include('Adding a README');
+      browser.html().should.containEql('Adding a README');
       done();
     });
   });

--- a/src/js-example/apps/commits/test/routes.js
+++ b/src/js-example/apps/commits/test/routes.js
@@ -26,7 +26,7 @@ describe('#index', function () {
 
   it('fetches the artsy github commits and renders the index page', function() {
     routes.index(req, res);
-    Backbone.sync.args[0][1].url().should.include('/repos/artsy/flare/commits');
+    Backbone.sync.args[0][1].url().should.containEql('/repos/artsy/flare/commits');
     Backbone.sync.args[0][2].success([{ message: 'hi' }]);
     res.render.args[0][0].should.equal('index');
     res.render.args[0][1].commits[0].get('message').should.equal('hi');

--- a/src/js-example/test/models/commit.js
+++ b/src/js-example/test/models/commit.js
@@ -22,7 +22,7 @@ describe('Commit', function() {
         owner: 'foo',
         repo: 'bar'
       });
-      commit.url().should.include('/repos/foo/bar/qux');
+      commit.url().should.containEql('/repos/foo/bar/qux');
     });
   });
 });


### PR DESCRIPTION
Updated calls to should.include to should.containEql in the example setup for CoffeeScript and JavaScript examples.
